### PR TITLE
Use Insights::Loggers::CloudWatch in logging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "clowder-common-ruby" # version specified in providers-common
 
 gem "concurrent-ruby"
 gem "faraday", "~> 1.0"
-gem "insights-loggers-ruby", "~> 0.1.9"
+gem "insights-loggers-ruby", "~> 0.1.10"
 gem "manageiq-messaging", "~> 1.0.0"
 gem "more_core_extensions"
 gem "optimist"

--- a/lib/sources/satellite/logging.rb
+++ b/lib/sources/satellite/logging.rb
@@ -12,17 +12,12 @@ module Sources
       if ENV['LOG_HANDLER'] == "haberdasher"
         "Insights::Loggers::StdErrorLogger"
       else
-        "TopologicalInventory::Providers::Common::Logger"
+        "Insights::Loggers::CloudWatch"
       end
     end
 
     def self.logger
-      log_params = {:app_name => APP_NAME}
-
-      if logger_class == "Insights::Loggers::StdErrorLogger"
-        log_params[:extend_module] = "TopologicalInventory::Providers::Common::LoggingFunctions"
-      end
-
+      log_params = {:app_name => APP_NAME, :extend_module => "TopologicalInventory::Providers::Common::LoggingFunctions"}
       @logger ||= Insights::Loggers::Factory.create_logger(logger_class, log_params)
     end
 


### PR DESCRIPTION
- Add `Insights::Loggers::CloudWatch` - we can set log level in container logger inside by `ENV['CONTAINER_LOG_LEVEL']`

if ENV['CONTAINER_LOG_LEVEL'] is not set, then ENV['LOG_LEVEL'] is used for container logging.