### PR TITLE
[RHCLOUD-18924] feature: use "latest" tag for the "ubi-minimal" image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.4-206
+FROM registry.access.redhat.com/ubi8/ubi:latest
 
 RUN dnf -y --disableplugin=subscription-manager module enable ruby:2.6 && \
     dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \


### PR DESCRIPTION
Time ago we were requested to use the "latest" tag from the security
team, so that the security updates would apply automatically on every
build.

This change makes us comply with that.

## Links

[[RHCLOUD-18924]](https://issues.redhat.com/browse/RHCLOUD-18924)